### PR TITLE
Fixed Docker image building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and Push Image
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           context: .
           cache-from: daystram/${{ env.APPLICATION }}:latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ $ go get -u github.com/daystram/caroline/cmd/caroline
 $ go install github.com/daystram/caroline/cmd/caroline@latest
 ```
 
+## Requirements
+
+To function properly, the following tools and library must be installed:
+
+- [ffmpeg](https://ffmpeg.org/)
+- [Opus](https://opus-codec.org/) development library
+
 ## Usage
 
 After providing the required configuration, the bot can simply be run as follows:


### PR DESCRIPTION
Docker image building seems to fail when building for linux/arm64. It appears that cgo's pkg-config was unable to detect the opus library during compilation. Thus, support for the arm64 arch will be dropped.