### PR TITLE
Fix failed command removal

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -60,7 +60,7 @@ func UnregisterAll(srv *server.Server) error {
 	}
 
 	for _, c := range cmds {
-		_ = srv.Session.ApplicationCommandDelete(srv.Session.State.User.ID, "", c.ID)
+		_ = srv.Session.ApplicationCommandDelete(srv.Session.State.User.ID, srv.DebugGuildID, c.ID)
 	}
 
 	return nil


### PR DESCRIPTION
Slash command removal did not appear to work properly before. Guild-specific commands did not get removed, and together with global application commands, it becomes polluted -- appearing duplicated.