### PR TITLE
Added playlist queueing

### DIFF
--- a/internal/domain/music.go
+++ b/internal/domain/music.go
@@ -2,24 +2,58 @@ package domain
 
 import (
 	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zmb3/spotify/v2"
 )
 
 type Music struct {
 	Query            string
-	Title            string
-	URL              string
-	Thumbnail        string
-	Duration         time.Duration
 	QueuedAt         time.Time
 	QueuedByID       string
 	QueuedByUsername string
-	Loaded           bool
+
+	Source         MusicSource
+	SpotifyTrackID string
+	YouTubeVideoID string
+
+	Loaded    bool
+	Title     string
+	URL       string
+	Thumbnail string
+	Duration  time.Duration
+}
+
+type MusicSource uint
+
+const (
+	MusicSourceSpotifyPlaylist MusicSource = iota
+	MusicSourceSpotifyTrack
+	MusicSourceYouTubeVideo
+	MusicSourceSearch
+)
+
+func (s MusicSource) String() string {
+	switch s {
+	case MusicSourceSpotifyPlaylist:
+		return "Spotify Playlist"
+	case MusicSourceSpotifyTrack:
+		return "Spotify"
+	case MusicSourceYouTubeVideo:
+		return "YouTube"
+	case MusicSourceSearch:
+		return "Search"
+	default:
+		return "invalid source"
+	}
 }
 
 type MusicUseCase interface {
+	Parse(query string, user *discordgo.User) (string, []*Music, error)
 }
 
 type MusicRepository interface {
-	SearchOne(query string) (*Music, error)
+	GetSpotifyPlaylist(id string) (*spotify.FullPlaylist, []spotify.PlaylistTrack, error)
+	Load(music *Music) error
 	GetStreamURL(music *Music) (string, error)
 }

--- a/internal/domain/queue.go
+++ b/internal/domain/queue.go
@@ -1,7 +1,5 @@
 package domain
 
-import "github.com/bwmarrin/discordgo"
-
 type Queue struct {
 	GuildID    string
 	Tracks     []*Music
@@ -39,7 +37,7 @@ func (q *Queue) NowPlaying() *Music {
 
 type QueueUseCase interface {
 	Get(guildID string) (*Queue, error)
-	AddQuery(q *Queue, query string, user *discordgo.User, pos int) (int, error)
+	Enqueue(q *Queue, music *Music, pos int) (int, error)
 	SetLoopMode(q *Queue, mode LoopMode) error
 }
 

--- a/internal/usecase/music.go
+++ b/internal/usecase/music.go
@@ -1,7 +1,20 @@
 package usecase
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+
 	"github.com/daystram/caroline/internal/domain"
+)
+
+var (
+	spotifyPlaylistRegex = regexp.MustCompile(`spotify\.com\/playlist\/(?P<playlistID>[^\?&"'>]+)`)
+	spotifyTrackRegex    = regexp.MustCompile(`spotify\.com\/track\/(?P<trackID>[^\?&"'>]+)`)
+	youtubeVideoRegex    = regexp.MustCompile(`(youtu\.be\/|youtube\.com\/(watch\?(.*&)?v=|(embed|v)\/))(?P<videoID>[^\?&"'>]+)`)
 )
 
 func NewMusicUseCase(musicRepo domain.MusicRepository) (domain.MusicUseCase, error) {
@@ -15,3 +28,62 @@ type musicUseCase struct {
 }
 
 var _ domain.MusicUseCase = (*musicUseCase)(nil)
+
+func (u *musicUseCase) Parse(query string, user *discordgo.User) (string, []*domain.Music, error) {
+	meta := ""
+	query = strings.TrimSpace(query)
+
+	musics := make([]*domain.Music, 0)
+	switch {
+	case spotifyPlaylistRegex.MatchString(query):
+		playlistID := spotifyPlaylistRegex.FindStringSubmatch(query)[spotifyPlaylistRegex.SubexpIndex("playlistID")]
+		p, tracks, err := u.musicRepo.GetSpotifyPlaylist(playlistID)
+		if err != nil {
+			return "", nil, err
+		}
+		for i, t := range tracks {
+			musics = append(musics, &domain.Music{
+				Query:            fmt.Sprintf("(%d) %s", i+1, query),
+				QueuedAt:         time.Now(),
+				QueuedByID:       user.ID,
+				QueuedByUsername: user.Username,
+				Source:           domain.MusicSourceSpotifyPlaylist,
+				SpotifyTrackID:   t.Track.ID.String(),
+			})
+		}
+		meta = p.Name
+
+	case spotifyTrackRegex.MatchString(query):
+		trackID := spotifyTrackRegex.FindStringSubmatch(query)[spotifyTrackRegex.SubexpIndex("trackID")]
+		musics = append(musics, &domain.Music{
+			Query:            query,
+			QueuedAt:         time.Now(),
+			QueuedByID:       user.ID,
+			QueuedByUsername: user.Username,
+			Source:           domain.MusicSourceSpotifyTrack,
+			SpotifyTrackID:   trackID,
+		})
+
+	case youtubeVideoRegex.MatchString(query):
+		videoID := youtubeVideoRegex.FindStringSubmatch(query)[youtubeVideoRegex.SubexpIndex("videoID")]
+		musics = append(musics, &domain.Music{
+			Query:            query,
+			QueuedAt:         time.Now(),
+			QueuedByID:       user.ID,
+			QueuedByUsername: user.Username,
+			Source:           domain.MusicSourceYouTubeVideo,
+			YouTubeVideoID:   videoID,
+		})
+
+	default:
+		musics = append(musics, &domain.Music{
+			Query:            query,
+			QueuedAt:         time.Now(),
+			QueuedByID:       user.ID,
+			QueuedByUsername: user.Username,
+			Source:           domain.MusicSourceSearch,
+		})
+	}
+
+	return meta, musics, nil
+}

--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -274,7 +274,7 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 				break statusSwitch
 			}
 			if !music.Loaded {
-				res, err := u.musicRepo.SearchOne(music.Query)
+				err := u.musicRepo.Load(music)
 				if err != nil {
 					_, _ = s.ChannelMessageSendEmbed(sp.StatusChannel.ID, &discordgo.MessageEmbed{
 						Title:       "Not Found",
@@ -284,11 +284,6 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 					wlog(err)
 					break statusSwitch
 				}
-				music.Title = res.Title
-				music.URL = res.URL
-				music.Thumbnail = res.Thumbnail
-				music.Duration = res.Duration
-				music.Loaded = true
 			}
 
 			surl, err := u.musicRepo.GetStreamURL(music)

--- a/internal/usecase/queue.go
+++ b/internal/usecase/queue.go
@@ -2,9 +2,6 @@ package usecase
 
 import (
 	"errors"
-	"time"
-
-	"github.com/bwmarrin/discordgo"
 
 	"github.com/daystram/caroline/internal/domain"
 )
@@ -38,17 +35,12 @@ func (u *queueUseCase) Get(guildID string) (*domain.Queue, error) {
 	return q, nil
 }
 
-func (u *queueUseCase) AddQuery(q *domain.Queue, query string, user *discordgo.User, pos int) (int, error) {
+func (u *queueUseCase) Enqueue(q *domain.Queue, music *domain.Music, pos int) (int, error) {
 	if q == nil {
 		return -1, domain.ErrQueueNotFound
 	}
 
-	trackNo, err := u.queueRepo.Enqueue(q.GuildID, &domain.Music{
-		Query:            query,
-		QueuedAt:         time.Now(),
-		QueuedByID:       user.ID,
-		QueuedByUsername: user.Username,
-	})
+	trackNo, err := u.queueRepo.Enqueue(q.GuildID, music)
 	if err != nil {
 		return -1, err
 	}

--- a/internal/util/np.go
+++ b/internal/util/np.go
@@ -26,6 +26,11 @@ func FormatNowPlaying(music *domain.Music, user *discordgo.User, start time.Time
 				Inline: false,
 			},
 			{
+				Name:   "Origin",
+				Value:  music.Source.String(),
+				Inline: true,
+			},
+			{
 				Name:   "Duration",
 				Value:  fmt.Sprintf("`%s/%s`", time.Since(start).String(), music.Duration.String()),
 				Inline: true,
@@ -33,11 +38,6 @@ func FormatNowPlaying(music *domain.Music, user *discordgo.User, start time.Time
 			{
 				Name:   "Queued By",
 				Value:  user.Mention(),
-				Inline: true,
-			},
-			{
-				Name:   "Queued At",
-				Value:  music.QueuedAt.Format(time.Kitchen),
 				Inline: true,
 			},
 		},


### PR DESCRIPTION
This PR reworks the music queueing sequence. All queries lodged will first be pre-loaded to break down potential playlists into singular tracks. This list of unloaded tracks will then be added to the queue. In this pre-loading step, all tracks will be labelled based on their sources, and platform-specific IDs will be loaded from their respective APIs. This source label will be used to load their corresponding YouTube match (with query re-building if necessary; e.g., Spotify tracks).

At the moment, only Spotify playlists are supported.