### PR TITLE
Added rolling playing status embed

### DIFF
--- a/internal/domain/player.go
+++ b/internal/domain/player.go
@@ -15,11 +15,12 @@ const (
 )
 
 type Player struct {
-	GuildID       string
-	VoiceChannel  *discordgo.Channel
-	StatusChannel *discordgo.Channel
-	Conn          *discordgo.VoiceConnection
-	Status        PlayerStatus
+	GuildID             string
+	VoiceChannel        *discordgo.Channel
+	StatusChannel       *discordgo.Channel
+	Conn                *discordgo.VoiceConnection
+	Status              PlayerStatus
+	LastStatusMessageID string
 
 	CurrentStartTime time.Time
 }

--- a/internal/util/np.go
+++ b/internal/util/np.go
@@ -33,6 +33,14 @@ func FormatNowPlaying(music *domain.Music, user *discordgo.User, start time.Time
 		}
 	}
 
+	var duration string
+	playtime := time.Since(start)
+	if playtime < time.Second {
+		duration = fmt.Sprintf("`%s`", music.Duration.String())
+	} else {
+		duration = fmt.Sprintf("`%s/%s`", playtime.String(), music.Duration.String())
+	}
+
 	return &discordgo.MessageEmbed{
 		Title:       "Now Playing",
 		Description: music.Title,
@@ -50,7 +58,7 @@ func FormatNowPlaying(music *domain.Music, user *discordgo.User, start time.Time
 			},
 			{
 				Name:   "Duration",
-				Value:  fmt.Sprintf("`%s/%s`", time.Since(start).String(), music.Duration.String()),
+				Value:  duration,
 				Inline: true,
 			},
 			{
@@ -66,5 +74,6 @@ func FormatNowPlaying(music *domain.Music, user *discordgo.User, start time.Time
 		Thumbnail: &discordgo.MessageEmbedThumbnail{
 			URL: music.Thumbnail,
 		},
+		Timestamp: start.Format(time.RFC3339),
 	}
 }


### PR DESCRIPTION
This prevents the playing status embeds from polluting the status channel. Now, status embeds will be updated on every new track being played. A new embed will be sent only if it is not on the latest message in the channel, thus guaranteeing that the most recent playing status is not outdated.