### PR TITLE
Fixed stuttering audio

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/daystram/caroline
 go 1.17
 
 require (
-	github.com/bwmarrin/dgvoice v0.0.0-20210225172318-caaac756e02e
 	github.com/bwmarrin/discordgo v0.24.0
+	github.com/daystram/dgvoice v0.0.0-20220308170814-a0065fb4d714
 	github.com/kkdai/youtube/v2 v2.7.10
 	github.com/zmb3/spotify/v2 v2.0.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkN
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/bwmarrin/dgvoice v0.0.0-20210225172318-caaac756e02e h1:IdfGDWLNL/ZAHda33oiKnkoaWWsQ6vyO+MDslrcJ43M=
-github.com/bwmarrin/dgvoice v0.0.0-20210225172318-caaac756e02e/go.mod h1:DT3heoMAQGrOExZ3Rb3TBOQ4Bm+wD4H48KFnt1YfLoQ=
 github.com/bwmarrin/discordgo v0.24.0 h1:Gw4MYxqHdvhO99A3nXnSLy97z5pmIKHZVJ1JY5ZDPqY=
 github.com/bwmarrin/discordgo v0.24.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -108,6 +106,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/daystram/dgvoice v0.0.0-20220308170814-a0065fb4d714 h1:ncNKBaBLi16Q8IOs5DtlvlrPJQoS0A4gF5PGuQfjCm4=
+github.com/daystram/dgvoice v0.0.0-20220308170814-a0065fb4d714/go.mod h1:HW5j2mqdo/6iG5akbLDZGpk7Pu0OkErQPTULaQOYizM=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 h1:Izz0+t1Z5nI16/II7vuEo/nHjodOg0p7+OiDpjX5t1E=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dop251/goja v0.0.0-20211211112501-fb27c91c26ed h1:93Xt1lY7ReTv+7uDM6UHe818CEvLLn5HE1gpB7d3MS8=

--- a/internal/repository/music.go
+++ b/internal/repository/music.go
@@ -130,7 +130,7 @@ func (r *musicRepository) GetStreamURL(music *domain.Music) (string, error) {
 		return "", err
 	}
 
-	f := v.Formats.Type("audio")
+	f := v.Formats.Type("audio/webm")
 	if len(f) == 0 {
 		return "", domain.ErrMusicNotFound
 	}

--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -355,7 +355,7 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 				case <-next:
 					stop <- true
 					break wait
-				case <-time.After(music.Duration + 5*time.Second):
+				case <-time.After(music.Duration + 15*time.Second):
 					stop <- true
 					wlog("timeout: playtime exceeded")
 					break wait

--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bwmarrin/dgvoice"
 	"github.com/bwmarrin/discordgo"
+	"github.com/daystram/dgvoice"
 
 	"github.com/daystram/caroline/internal/common"
 	"github.com/daystram/caroline/internal/domain"


### PR DESCRIPTION
Previously, Caroline stutters when playing audio in multiple voice channels. This might have been caused by a bug in the previously used PCM streamer library. Audio can also sometimes be skippy and stops early, thus audio source format is changed from `audio/mp4` to `audio/webm`. The WebM audio with Opus encoding appears to be clearer and less skippy. Player timeout is also increased to counter player loading times.