### PR TITLE
Fix discordgo listener panic

### DIFF
--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -240,7 +240,7 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 	wlog := util.NewPlayerWorkerLogger(sp.GuildID)
 	wlog("starting worker")
 
-	conn, err := s.ChannelVoiceJoin(vch.GuildID, vch.ID, false, false)
+	conn, err := s.ChannelVoiceJoin(vch.GuildID, vch.ID, false, true)
 	if err != nil {
 		wlog(err)
 		return err


### PR DESCRIPTION
Discordgo occasionally triggers a panic when attempting to parse Opus packets in its listener worker. Since this listener is not needed, this issue is circumvented by disabling it, simply by self-deafening when joining a voice channel.