### PR TITLE
Fixed nil pointer in youtube-dl executor

### DIFF
--- a/internal/repository/music.go
+++ b/internal/repository/music.go
@@ -133,10 +133,10 @@ type YouTubeDLResponse struct {
 }
 
 type YouTubeDLFormat struct {
-	URL        string  `json:"url"`
-	Ext        string  `json:"ext"`
-	AudioCodec string  `json:"acodec"`
-	AvgBitrate float32 `json:"abr"`
+	URL          string  `json:"url"`
+	Ext          string  `json:"ext"`
+	AudioCodec   string  `json:"acodec"`
+	AudioBitrate float32 `json:"abr"`
 }
 
 type YouTubeDLThumbnail struct {
@@ -192,6 +192,6 @@ func filterFormats(formats []YouTubeDLFormat, ext, acodec string) []YouTubeDLFor
 
 func sortFormats(formats []YouTubeDLFormat) {
 	sort.SliceStable(formats, func(i, j int) bool {
-		return formats[i].AvgBitrate > formats[j].AvgBitrate
+		return formats[i].AudioBitrate > formats[j].AudioBitrate
 	})
 }

--- a/internal/repository/music.go
+++ b/internal/repository/music.go
@@ -94,7 +94,7 @@ func (r *musicRepository) Load(m *domain.Music) error {
 	if err != nil {
 		return err
 	}
-	if resp.ID == "" {
+	if resp == nil || resp.ID == "" {
 		return domain.ErrMusicNotFound
 	}
 
@@ -170,10 +170,10 @@ func execYouTubeDL(arg ...string) (*YouTubeDLResponse, error) {
 
 	for i := 0; i < youtubeDLRetries; i++ {
 		resp, err := exec(arg...)
-		if err != nil {
+		if err == nil {
 			return resp, nil
 		}
-		log.Printf("youtube-dl: attempt #%d: %s", i, err.Error())
+		log.Printf("youtube-dl: attempt #%d: %s", i, err)
 	}
 
 	return nil, domain.ErrMusicNotFound

--- a/internal/repository/music.go
+++ b/internal/repository/music.go
@@ -149,7 +149,7 @@ func execYouTubeDL(arg ...string) (*YouTubeDLResponse, error) {
 	exec := func(arg ...string) (*YouTubeDLResponse, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		cmd := exec.CommandContext(ctx, "youtube-dl", append(arg, "--dump-json")...)
+		cmd := exec.CommandContext(ctx, "youtube-dl", append(arg, "--dump-json", "--force-ipv4")...)
 
 		var out bytes.Buffer
 		cmd.Stdout = &out

--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -359,7 +359,7 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 				case <-next:
 					stop <- true
 					break wait
-				case <-time.After(music.Duration + 15*time.Second):
+				case <-time.After(music.Duration + 30*time.Second):
 					stop <- true
 					wlog("timeout: playtime exceeded")
 					break wait


### PR DESCRIPTION
Fixed youtube-dl retry bug. Forced IPv4 in youtube-dl to fix reliability issues. Timeout for player worker extended to 30s.