### PR TITLE
Use yt-dlp instead of youtube-dl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go build -ldflags="-X 'github.com/daystram/caroline/internal/config.version=
 FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y ffmpeg libopus0 libopus-dev && apt-get clean
 RUN apt-get update && apt-get install -y curl python && apt-get clean
-RUN curl -L https://yt-dl.org/downloads/2021.12.17/youtube-dl -o /usr/local/bin/youtube-dl && chmod a+rx /usr/local/bin/youtube-dl
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp -o /usr/local/bin/yt-dlp && chmod a+rx /usr/local/bin/yt-dlp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/caroline /usr/local/bin/
 CMD ["/usr/local/bin/caroline"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To function properly, the following tools and library must be installed:
 
 - [ffmpeg](https://ffmpeg.org/)
 - [Opus](https://opus-codec.org/) development library
-- [youtube-dl](https://github.com/ytdl-org/youtube-dl)
+- [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 
 ## Usage
 
@@ -53,7 +53,6 @@ The bot could be configured by setting the following environment variables.
 | `BOT_TOKEN`        | Discord Bot token      | `""`    | ✅       |
 | `SP_CLIENT_ID`     | Spotify client ID      | `""`    | ✅       |
 | `SP_CLIENT_SECRET` | Spotify client secret  | `""`    | ✅       |
-| `YT_API_KEY`       | YouTube API key        | `""`    | ✅       |
 | `DEBUG_GUILD_ID`   | Discord debug Guild ID | `""`    | ⬜       |
 
 ## License

--- a/internal/usecase/player.go
+++ b/internal/usecase/player.go
@@ -328,6 +328,7 @@ func (u *playerUseCase) StartWorker(s *discordgo.Session, sp *speaker, vch, sch 
 				sp.LastStatusMessageID = msg.ID
 
 				if sp.Conn != nil && sp.Conn.Ready {
+					wlog(fmt.Sprintf("play: stream url: %s", surl))
 					dgvoice.PlayAudioFile(sp.Conn, surl, stop)
 				} else {
 					wlog("stop: conn is not ready")


### PR DESCRIPTION
There were some issues with the JSON output mode on youtube-dl where content metadata failed to parse properly. yt-dlp does not seem to have this issue.