### PR TITLE
Properly filter formats to get stream URL

### DIFF
--- a/internal/repository/music.go
+++ b/internal/repository/music.go
@@ -122,7 +122,7 @@ func (r *musicRepository) GetStreamURL(music *domain.Music) (string, error) {
 	}
 	sortFormats(f)
 
-	return resp.Formats[0].URL, nil
+	return f[0].URL, nil
 }
 
 type YouTubeDLResponse struct {


### PR DESCRIPTION
Content formats were not properly filtered and sorted. This PR fixes the issue.