### PR TITLE
Install python3 for yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go build -ldflags="-X 'github.com/daystram/caroline/internal/config.version=
 
 FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y ffmpeg libopus0 libopus-dev && apt-get clean
-RUN apt-get update && apt-get install -y curl python && apt-get clean
+RUN apt-get update && apt-get install -y curl python3 && apt-get clean
 RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.03.04/yt-dlp -o /usr/local/bin/yt-dlp && chmod a+rx /usr/local/bin/yt-dlp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/caroline /usr/local/bin/


### PR DESCRIPTION
yt-dlp requries python3. This PR adds python3 to the Docker image.